### PR TITLE
C2C-432: Install `sqlalchemy-drill`, `pydrill` dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM apache/superset:4.0.1
 # Switching to root to install the required packages
 USER root
 
-RUN pip install authlib
+RUN pip install sqlalchemy-drill pydrill
 
 # Switching back to using the `superset` user
 USER superset

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM apache/superset:4.0.1
 # Switching to root to install the required packages
 USER root
 
-RUN pip install sqlalchemy-drill pydrill
+RUN pip install authlib sqlalchemy-drill pydrill
 
 # Switching back to using the `superset` user
 USER superset


### PR DESCRIPTION
Fix missing dependacies in the image part of the fix for https://mekomsolutions.atlassian.net/browse/C2C-432